### PR TITLE
Remove use of set_context

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -168,8 +168,6 @@ class SkillIoTControl(MycroftSkill):
             self._trigger_iot_request(data, action, thing, attribute,
                                       original_entity, original_scene)
 
-        self._set_context(thing, entity, data)
-
     def _trigger_iot_request(self, data: dict,
                              action: Action,
                              thing: Thing=None,


### PR DESCRIPTION
Context is causing problems with sticky things and entities. Until this
can be resolved, context will not be used.