### PR TITLE
Allow the value to be 0

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -166,7 +166,8 @@ class SkillIoTControl(MycroftSkill):
 
         if action == Action.SET and 'TO' in data:
             value = extract_number(message.data['utterance'])
-            value = value if value else None  # extract_number may return False
+            # extract_number may return False:
+            value = value if value is not False else None
 
         original_entity = (self._normalized_to_orignal_word_map.get(entity)
                            if entity else None)


### PR DESCRIPTION
If the extracted value was 0 it would be sent as None, this checks explicitly for the `False` response of extract_number function.